### PR TITLE
feat: add disabling btn for already bought good

### DIFF
--- a/src/pages/cart/cart.ts
+++ b/src/pages/cart/cart.ts
@@ -429,9 +429,7 @@ export default class CartView extends Component {
   }
 
   private async refreshCart(): Promise<void> {
-    // await this.renderHeading();
     await State.refreshCart();
-    // console.log(State.cart?.body.lineItems);
     if (State.cart?.body.lineItems.length === 0) {
       this.cartContainer.innerHTML = '';
       this.renderEmptyCart();
@@ -443,9 +441,7 @@ export default class CartView extends Component {
   }
 
   public async renderHTML(): Promise<HTMLElement> {
-    // await this.renderHeading();
-    await State.setCart(() => {} /* error handling */);
-    // console.log(State.cart?.body.lineItems);
+    await State.setCart(() => {});
     if (State.cart?.body.lineItems.length === 0) {
       this.cartContainer.innerHTML = '';
       this.renderEmptyCart();

--- a/src/pages/catalog/catalog.ts
+++ b/src/pages/catalog/catalog.ts
@@ -19,7 +19,8 @@ import ItemView from '../item/item';
 import {
   GetAnonimCartByID,
   addToAnonimCart,
-  addToCart
+  addToCart,
+  GetCart
 } from '../../api/apiMethods';
 
 Swiper.use([Navigation, Pagination]);
@@ -303,9 +304,23 @@ export default class CatalogView extends Component {
     const toCartBtn = document.createElement('button');
     toCartBtn.className = 'to_cart-btn btn btn--yellow order-submit';
     toCartBtn.textContent = 'Add to cart';
+    toCartBtn.setAttribute('data-name', `${catalogItem.slug.en}`);
+
+    const cartArray = State.cart?.body.lineItems.map((el) => {
+      return el.name.en.toLowerCase();
+    });
+    if (cartArray?.includes(catalogItem.slug.en)) {
+      toCartBtn.setAttribute('disabled', 'true');
+    }
     toCartBtn.addEventListener('click', async (e) => {
       e.preventDefault();
       const CART_ID = localStorage.getItem('cartID');
+
+      /* корзина
+      if (!CART_ID) throw new Error('error');
+      let cartCheck = await GetAnonimCartByID(CART_ID);
+      console.log('cart', cartCheck.body.lineItems[1].name.en); */
+
       if (!CART_ID) {
         await State.setCart();
       }

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -4,6 +4,7 @@ import {
   Cart,
   CategoryPagedQueryResponse,
   ClientResponse,
+  LineItem,
   ProductProjectionPagedQueryResponse
 } from '@commercetools/platform-sdk';
 import {
@@ -108,6 +109,18 @@ export default abstract class State {
         } else {
           State.cart = await GetAnonimCartByID(CART_ID);
         }
+
+        const cartArray = State.cart?.body.lineItems.map((el) => {
+          return el.name.en.toLowerCase();
+        });
+        const toCartBtns = document.getElementsByClassName('to_cart-btn');
+        Array.from(toCartBtns).forEach((el) => {
+          const productName = el.getAttribute('data-name');
+          if (!productName) throw new Error('err');
+          if (cartArray?.includes(productName)) {
+            el.setAttribute('disabled', 'true');
+          }
+        });
       }
     } catch {
       if (handleError) handleError();


### PR DESCRIPTION
## Task
[Sprint 4](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%234.md)
<!-- 
Provide a task name with a link to it, for example:
[Repository Setup](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%231.md#1-repository-setup-29-points-)
-->

## Description
_This PR disabled 'toCartBtn' if good already in the cart._

_..._
<!-- 
Describe what the change is and how it was implemented.
-->

## What type of PR is this? (check all applicable)
- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Optimization
- [ ] Documentation Update

## Mobile & Desktop Screenshots/Recordings
<!-- Visual changes require screenshots -->
![1](https://github.com/Ir4D/eCommerce-Application/assets/79801453/4ff1b37b-3b18-4472-9d79-0e00423d1c56)

## Added to documentation?
- [ ] README.md
- [x] no documentation needed

## [optional] Other notes
<!-- 
Add any additional information that would be useful to the developer or mentor 
-->
